### PR TITLE
manager: remove become from network playbook

### DIFF
--- a/environments/manager/playbook-network.yml
+++ b/environments/manager/playbook-network.yml
@@ -3,7 +3,6 @@
 
 - name: Apply role network
   hosts: manager
-  become: true
 
   collections:
     - osism.commons


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>