### PR TITLE
Add loadbalancer group

### DIFF
--- a/inventory/50-kolla
+++ b/inventory/50-kolla
@@ -74,6 +74,9 @@ control
 [kibana:children]
 control
 
+[loadbalancer:children]
+control
+
 [magnum:children]
 control
 


### PR DESCRIPTION
Starting with Xena, the loadbalancer group is required.
To be downward compatible for the time being, OSISM
continues to use haproxy internally for the moment.

The haproxy group is deprecated as of now and will be
removed in the future.

Signed-off-by: Christian Berendt <berendt@osism.tech>