### PR TITLE
Use the loadbalancer group instead of the haproxy group

### DIFF
--- a/inventory/50-kolla
+++ b/inventory/50-kolla
@@ -48,7 +48,7 @@ storage
 control
 
 [haproxy:children]
-control
+loadbalancer
 
 [heat:children]
 control

--- a/inventory/51-kolla
+++ b/inventory/51-kolla
@@ -377,7 +377,7 @@ storage
 elasticsearch
 
 [prometheus-haproxy-exporter:children]
-haproxy
+loadbalancer
 
 [prometheus-memcached-exporter:children]
 memcached


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>