### PR TITLE
Remove tailscale

### DIFF
--- a/inventory/50-infrastruture
+++ b/inventory/50-infrastruture
@@ -49,9 +49,6 @@ manager
 [zuul:children]
 manager
 
-[tailscale:children]
-manager
-
 [nexus:children]
 manager
 


### PR DESCRIPTION
There are security concerns about Tailscale.
Accordingly, it is removed again.

Signed-off-by: Christian Berendt <berendt@osism.tech>