### PR TITLE
Add paramiko as requirement

### DIFF
--- a/environments/manager/requirements.txt
+++ b/environments/manager/requirements.txt
@@ -3,3 +3,4 @@
 ansible==5.5.0
 debops==3.0.1
 netaddr==0.8.0
+paramiko==2.10.3


### PR DESCRIPTION
When running docker login, paramiko is required.

Signed-off-by: Uwe Grawert <grawert@b1-systems.de>