### PR TITLE
inventory: remove kubectl group

### DIFF
--- a/inventory/50-infrastruture
+++ b/inventory/50-infrastruture
@@ -35,9 +35,6 @@ manager
 [keycloak:children]
 manager
 
-[kubectl:children]
-manager
-
 [mirror:children]
 manager
 


### PR DESCRIPTION
It's already part of k3s.