### PR TITLE
Fix wrong mariadb parameters in images.yml

### DIFF
--- a/environments/manager/images.yml
+++ b/environments/manager/images.yml
@@ -7,8 +7,8 @@ adminer_image: "{{ '{{' }} docker_registry {{ '}}' }}/{{ images['adminer'] }}:{{
 ara_server_tag: "{{ versions['ara_server'] }}"
 ara_server_image: "{{ '{{' }} docker_registry_ansible|default('quay.io') {{ '}}' }}/{{ images['ara_server'] }}:{{ '{{' }} ara_server_tag {{ '}}' }}"
 
-mariadb_tag: "{{ versions['mariadb'] }}"
-mariadb_image: "{{ '{{' }} docker_registry {{ '}}' }}/{{ images['mariadb'] }}:{{ '{{' }} mariadb_tag {{ '}}' }}"
+ara_server_mariadb_tag: "{{ versions['mariadb'] }}"
+ara_server_mariadb_image: "{{ '{{' }} docker_registry {{ '}}' }}/{{ images['mariadb'] }}:{{ '{{' }} mariadb_tag {{ '}}' }}"
 
 netbox_tag: "{{ versions['netbox'] }}"
 netbox_image: "{{ '{{' }} docker_registry_netbox|default('quay.io') {{ '}}' }}/{{ images['netbox'] }}:{{ '{{' }} netbox_tag {{ '}}' }}"


### PR DESCRIPTION
fix variable name in ara_server_mariadb_image to use ara_server_mariadb_tag instead of mariadb_tag.

Closes osism/issues#609