### PR TITLE
Revert "chore(deps): update dependency ansible to v9.5.0 (#421)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Jinja2==3.1.3
 PyYAML==6.0.1
-ansible==9.5.0
+ansible==9.4.0
 pwgen==0.8.2.post0
 python-gilt==1.2.3
 requests==2.31.0


### PR DESCRIPTION
This release was yanked:
Accidently contains breaking change

This reverts commit 25e6d35b622095c28074fa63c293888bc6e0d6c3.