### PR TITLE
Do not use rstrip in set-versions.py

### DIFF
--- a/src/set-versions.py
+++ b/src/set-versions.py
@@ -49,7 +49,7 @@ try:
             data,
         )
         fp.seek(0)
-        fp.write(data.rstrip())
+        fp.write(data)
 except FileNotFoundError:
     pass
 
@@ -66,7 +66,7 @@ try:
         data = fp.read()
         data = re.sub("docker_version: .*", f"docker_version: '{docker_version}'", data)
         fp.seek(0)
-        fp.write(data.rstrip())
+        fp.write(data)
 except FileNotFoundError:
     pass
 
@@ -75,6 +75,6 @@ try:
         data = fp.read()
         data = re.sub("docker_version: .*", f"docker_version: '{docker_version}'", data)
         fp.seek(0)
-        fp.write(data.rstrip())
+        fp.write(data)
 except FileNotFoundError:
     pass


### PR DESCRIPTION
Due to an error during testing, it looked as if \n had to be removed before writing. It is not the case.

Related to 6e1083e6eade309ea83c8b89a8884496b811469d