### PR TITLE
Use correct version in gilt.yml

### DIFF
--- a/src/set-versions.py
+++ b/src/set-versions.py
@@ -27,8 +27,26 @@ versions = yaml.full_load(r.text)
 
 commons_version = versions["ansible_collections"]["osism.commons"]
 docker_version = versions["osism_projects"]["docker"]
+generics_version = versions["generics_version"]
 playbooks_manager = versions.get("manager_playbooks_version", "main")
 services_version = versions["ansible_collections"]["osism.services"]
+
+# manage generics version in gilt.yml
+
+try:
+    with open("../gilt.yml", "r+") as fp:
+        data = fp.read()
+        data = re.sub(
+            "version: .*",
+            f"version: {generics_version}",
+            data,
+        )
+        fp.seek(0)
+        fp.write(data)
+except FileNotFoundError:
+    pass
+
+# manage ansible collection versions in manager/run.sh
 
 try:
     with open("manager/run.sh", "r+") as fp:
@@ -52,6 +70,8 @@ try:
         fp.write(data)
 except FileNotFoundError:
     pass
+
+# manage docker version in environments/configuration.yml and environments/manager/configuration.yml
 
 print(
     "The docker_version parameter in environments/configuration.yml and"


### PR DESCRIPTION
The version used in the gilt.yml file is now read and set from osism/release according to the manager version.

Closes osism/issues#738