### PR TITLE
Do not use extensions only avaiable in GNU sed

### DIFF
--- a/environments/manager/run.sh
+++ b/environments/manager/run.sh
@@ -51,7 +51,7 @@ fi
 command -v ansible-playbook >/dev/null 2>&1 || { echo >&2 "ansible-playbook not installed"; exit 1; }
 command -v ansible-galaxy >/dev/null 2>&1 || { echo >&2 "ansible-galaxy not installed"; exit 1; }
 
-configured_branch="$(grep -E "^configuration_git_version:"  "$RUNDIR/configuration.yml"|sed '~s,^..*:[ ]*,,')"
+configured_branch="$(grep -E "^configuration_git_version:"  "$RUNDIR/configuration.yml" | sed 's/^..*:[ ]*//')"
 current_branch="$(git rev-parse --abbrev-ref HEAD)"
 
 if [ "$configured_branch" != "$current_branch" ];then


### PR DESCRIPTION
The ~ is a GNU sed specific extension.

This one works:

```
$ grep -E "^configuration_git_version:"  "$RUNDIR/configuration.yml"|gsed '~s,^..*:[ ]*,,'
main
```

This one fails:

```
$ grep -E "^configuration_git_version:"  "$RUNDIR/configuration.yml"|sed '~s,^..*:[ ]*,,'
sed: 1: "~s,^..*:[ ]*,,": invalid command code ~
```

Also use / instead of ,

Closes osism/issues#1020