### PR TITLE
inventory: by default use generic for the frr service

### DIFF
--- a/inventory/60-generic
+++ b/inventory/60-generic
@@ -19,6 +19,7 @@ rabbitmq
 generic
 
 [frr:children]
+generic
 
 [hddtemp:children]
 generic


### PR DESCRIPTION
Related to osism/ansible-playbooks#498