### PR TITLE
inventory: remove old dragonfly groups

### DIFF
--- a/inventory/50-infrastruture
+++ b/inventory/50-infrastruture
@@ -10,12 +10,6 @@ manager
 [dnsdist:children]
 manager
 
-[dragonfly_client:children]
-generic
-
-[dragonfly_server:children]
-manager
-
 [helper:children]
 manager
 


### PR DESCRIPTION
Has never been used, can go.