### PR TITLE
manager: add interpreter_python = auto_silent

### DIFF
--- a/environments/manager/ansible.cfg
+++ b/environments/manager/ansible.cfg
@@ -7,6 +7,12 @@ pipelining = true
 # use -vvvv to see details" warning message
 force_valid_group_names = ignore
 
+# Avoid warnings that future installation of another Python interpreter
+# could alter the one chosen.
+#
+# https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html
+interpreter_python = auto_silent
+
 host_key_checking = false
 remote_user = dragon
 retry_files_enabled = false


### PR DESCRIPTION
Avoid warnings that future installation of another Python interpreter could alter the one chosen.

https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html