### PR TITLE
Set VAULT to .vault_pass when file exists in run.sh

### DIFF
--- a/environments/manager/run.sh
+++ b/environments/manager/run.sh
@@ -80,7 +80,9 @@ if [[ "$playbook" == "noop" ]]; then
     exit 0
 fi
 
-if [[ \
+if [[ -e .vault_pass ]]; then
+    VAULT=.vault_pass
+elif [[ \
       $(head -1 secrets.yml | grep -v -q \$ANSIBLE_VAULT || echo 1) == 1 || \
       $(head -1 ../secrets.yml | grep -v -q \$ANSIBLE_VAULT || echo 1) == 1 || \
       $(head -1 ../infrastructure/secrets.yml | grep -v -q \$ANSIBLE_VAULT || echo 1) == 1 \


### PR DESCRIPTION
Add automatic detection of .vault_pass file in the manager environment. If the file exists, VAULT is set to .vault_pass to use it as the vault password file for ansible-playbook commands.