### PR TITLE
manager: use pinned kolla-ansible tag for latest

### DIFF
--- a/environments/manager/images.yml
+++ b/environments/manager/images.yml
@@ -93,14 +93,10 @@ ceph_ansible_tag: "{{ '{{' }} ceph_version|default(manager_version) {{ '}}' }}"
 {% endif -%}
 ceph_ansible_image: "{{ '{{' }} docker_registry_ansible|default('registry.osism.tech') {{ '}}' }}/{{ images['ceph_ansible'] }}:{{ '{{' }} ceph_ansible_tag {{ '}}' }}"
 
-{% if manager_version == 'latest' -%}
-kolla_ansible_tag: "{{ '{{' }} openstack_version|default('2024.2') {{ '}}' }}"
-{% else -%}
 {% if 'kolla_ansible' in versions -%}
 kolla_ansible_tag: "{{ versions['kolla_ansible'] }}"
 {% else -%}
 kolla_ansible_tag: "{{ '{{' }} openstack_version|default(manager_version) {{ '}}' }}"
-{% endif -%}
 {% endif -%}
 kolla_ansible_image: "{{ '{{' }} docker_registry_ansible|default('registry.osism.tech') {{ '}}' }}/{{ images['kolla_ansible'] }}:{{ '{{' }} kolla_ansible_tag {{ '}}' }}"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ PyYAML==6.0.3
 ansible==11.13.0
 packaging==26.1
 pwgen==0.8.2.post0
+pytest==9.0.3
 python-gilt==1.2.3
 requests==2.33.1
 tabulate==0.10.0

--- a/tests/test_render_images_template.py
+++ b/tests/test_render_images_template.py
@@ -1,0 +1,29 @@
+from collections import defaultdict
+import os
+import jinja2
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TEMPLATE = "environments/manager/images.yml"
+
+
+def render(manager_version, versions_extra=None):
+    versions = defaultdict(str, versions_extra or {})
+    images = defaultdict(str)
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader(REPO_ROOT))
+    return env.get_template(TEMPLATE).render(
+        images=images, manager_version=manager_version, versions=versions
+    )
+
+
+def test_latest_with_pinned_kolla_ansible_uses_pinned_tag():
+    # When manager_version=latest and kolla_ansible is present in versions
+    # (as it is once release/latest/base.yml is updated), the rendered
+    # tag must be the pinned value, not openstack_version.
+    result = render("latest", {"kolla_ansible": "0.20260328.0"})
+    assert 'kolla_ansible_tag: "0.20260328.0"' in result
+
+
+def test_pinned_release_with_kolla_ansible_uses_pinned_tag():
+    # Regression: pinned manager_version must continue to use the pinned tag.
+    result = render("10.0.0", {"kolla_ansible": "0.20260328.0"})
+    assert 'kolla_ansible_tag: "0.20260328.0"' in result

--- a/tox.ini
+++ b/tox.ini
@@ -30,3 +30,4 @@ setenv =
 commands =
    python3 src/render-images.py
    cat images.yml
+   python3 -m pytest tests


### PR DESCRIPTION
## Summary

- Removes the `{% if manager_version == 'latest' %}` bypass for `kolla_ansible_tag` in `environments/manager/images.yml`
- Adds `pytest==9.0.3` to `requirements.txt`
- Adds `tests/test_render_images_template.py` verifying the pinned tag is used when `kolla_ansible` is present in versions

This is the generics-side half of a two-repo fix for `kolla/release/2025.1/fluentd:2025.1 not found` 500 errors in `testbed-upgrade-stable-next-ubuntu-24.04`. The bypass caused `kolla_ansible_tag` to resolve to `openstack_version` (e.g. `2025.1`) for `manager_version=latest`, which does not exist in the `kolla/release/2025.1/` namespace.

**Depends on** osism/release#2494 (already merged or pending merge — do not merge this PR first).

## Scope

This PR, together with osism/release#2494, is the **complete fix for stable releases** (e.g. `10.0.0`). For stable releases, the OpenStack version is baked into the kolla-ansible image at build time — the `container-image-kolla-ansible` build script reads `latest/openstack.yml` from the release repo at the `kolla-ansible-$version` git tag. Each stable OSISM point release therefore carries exactly one kolla-ansible pin in `base.yml` targeting exactly one OpenStack version, and no further machinery is needed.

For `manager_version=latest`, this PR fixes the `openstack_version=2025.1` case. Correct handling of other `openstack_version` values under `latest` (e.g. `2024.2`) requires a follow-up: a per-OpenStack overlay-loading change in `render-images.py` and corresponding per-OpenStack kolla-ansible pins in the release overlay files (`latest/openstack-2024.2.yml`, etc.).

## Test plan

- [x] `test_latest_with_pinned_kolla_ansible_uses_pinned_tag` passes
- [x] `test_pinned_release_with_kolla_ansible_uses_pinned_tag` passes
- [x] `tox -e check` passes
- [ ] `MANAGER_VERSION=latest tox -e test` produces `kolla_ansible_tag: 0.20260328.0` — requires osism/release#2494 merged first
- [x] `MANAGER_VERSION=9.1.0 tox -e test` passes
- [x] `MANAGER_VERSION=9.0.0 tox -e test` passes (fallback path, exits 0)
- [x] `flake8` passes