### PR TITLE
inventory: add neutron 2025.2 service groups

### DIFF
--- a/inventory/51-kolla
+++ b/inventory/51-kolla
@@ -250,11 +250,20 @@ neutron
 [neutron-ovn-agent:children]
 compute
 
+[neutron-ovn-maintenance-worker:children]
+control
+
 [neutron-ovn-metadata-agent:children]
 compute
 
 [neutron-ovn-vpn-agent:children]
 network
+
+[neutron-periodic-worker:children]
+control
+
+[neutron-rpc-server:children]
+control
 
 [neutron-server:children]
 control


### PR DESCRIPTION
## What

Add three kolla inventory groups to `inventory/51-kolla`, all mapping to `control` (mirroring `neutron-server`):

- `[neutron-rpc-server:children]`
- `[neutron-periodic-worker:children]`
- `[neutron-ovn-maintenance-worker:children]`

## Why

kolla-ansible `stable/2025.2` split three new, default-enabled services out of `neutron-server`, each carrying `host_in_groups: "{{ inventory_hostname in groups['<name>'] }}"`. Building the haproxy-config `with_dict` loop templates the whole `neutron_services` dict, so every entry's `host_in_groups` is evaluated; a lookup on a group absent from this inventory aborts templating with `'dict object' has no attribute 'neutron-rpc-server'` (the "dict object" is the `groups` var, not `neutron_services`).

This inventory shipped `neutron-server` but never gained the three new groups, so **`testbed-upgrade-stable-next-ubuntu-24.04` fails during "Run upgrade"** once the 2025.2 neutron role is in play. The failure surfaces on `neutron-rpc-server` first only because templating stops at the first missing key — the other two groups are the same gap and would surface next.

`stable/2025.2 ansible/inventory/multinode` places all three under `control`, which this change matches.

## Context

This is one wall in a 2025.2-upgrade "gauntlet" of new-service wiring deficits: each cleared blocker exposes the next. The immediately preceding wall was the keystone-httpd image (`'docker_image_url' is undefined`). Image overrides for these neutron services already exist in `osism/defaults`; this closes the remaining **inventory-group** side.

## Timeline (observed)

| Date | Failure point |
|------|---------------|
| 06-19 / 06-20 | keystone-httpd image (`docker_image_url` undefined) — before neutron |
| 06-21 | this gap (`neutron-rpc-server` group) — first reached |
| 06-22 / 06-23 | masked by earlier pre-neutron failures (SSH timeout, bootstrap) |
| 06-24 | this gap again |

## Caveat

Won't go quiet until merged **and** the nightly manager picks up the new `osism.generics` tag via gilt. Clearing neutron may expose whatever is immediately downstream — but the static wiring gap is closed here.