### PR TITLE
inventory: add ironic-dnsmasq service group

### DIFF
--- a/inventory/51-kolla
+++ b/inventory/51-kolla
@@ -148,6 +148,9 @@ ironic
 [ironic-conductor:children]
 ironic
 
+[ironic-dnsmasq:children]
+ironic
+
 [ironic-http:children]
 ironic
 


### PR DESCRIPTION
## What

Add the `ironic-dnsmasq` inventory group (child of `ironic`) to
`inventory/51-kolla`, mirroring kolla-ansible `stable/2025.2`
`ansible/inventory/multinode`.

## Why

kolla-ansible `stable/2025.2` ships an `ironic-dnsmasq` group in its
`multinode` inventory, but this inventory never gained it. The ironic role
dereferences `groups['ironic-dnsmasq']` **unconditionally** — it appears as
`groups['ironic-dnsmasq'] | length > 0` in:

- `ironic/tasks/config.yml` (4×) and `ironic/tasks/precheck.yml` `when:` conditions
- the `ironic-http.json.j2` and `ironic-tftp.json.j2` container config templates

These expressions are evaluated on every ironic deployment, *before* any
enable check. With the group undefined, Ansible aborts with:

```
'dict object' has no attribute 'ironic-dnsmasq'
```

(the "dict object" being the `groups` var). This breaks every ironic-enabled
deployment; only setups that do not deploy ironic (e.g. the virtualized
testbed) are unaffected.

## Same class of fix as the neutron 2025.2 groups

This is the identical failure mode and remedy as the recent neutron change:

- osism/generics#599

## Validation

- `tox -e check` (inventory sorting) passes with the group inserted in
  alphabetical order between `ironic-conductor` and `ironic-http`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
