### PR TITLE
check-kolla-inventory: gate CI on inventory drift

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -30,6 +30,12 @@
       tox_envlist: check
 
 - job:
+    name: generics-tox-check-kolla
+    parent: tox
+    vars:
+      tox_envlist: check-kolla
+
+- job:
     name: generics-tox-seed
     parent: tox
     vars:
@@ -41,6 +47,7 @@
     check:
       jobs:
         - generics-tox-check
+        - generics-tox-check-kolla
         - generics-tox-seed
         - generics-tox-test-latest
         - generics-tox-test-stable
@@ -52,6 +59,7 @@
     periodic-daily:
       jobs:
         - generics-tox-check
+        - generics-tox-check-kolla
         - generics-tox-seed
         - generics-tox-test-latest
         - generics-tox-test-stable

--- a/src/check-kolla-inventory.py
+++ b/src/check-kolla-inventory.py
@@ -6,30 +6,30 @@ import sys
 
 import requests
 
-# Group name prefixes that exist in the upstream kolla-ansible inventory but
-# that OSISM intentionally does not mirror. A group belongs here only if OSISM
-# deliberately never deploys the corresponding service; otherwise the group
-# must be defined in inventory/ instead (see the message printed on drift).
-IGNORE = [
-    "baremetal",
-    "blazar",
-    "collectd",
+# kolla-ansible inventory groups that exist upstream but that this inventory
+# does not mirror, by design. There are two kinds, matched differently.
+#
+# Host-role groups: the physical node groups (control, compute, ...) that
+# services map onto. OSISM populates these from the operator's environment
+# inventory, not from 50-/51-kolla, so upstream's definitions of them are not
+# drift. Matched by exact name.
+IGNORE_ROLE_GROUPS = [
+    "baremetal:children",
     "compute",
     "control",
-    "cyborg",
     "deployment",
-    "freezer",
-    "masakari",
     "monitoring",
-    "murano",
     "network",
-    "sahara",
-    "solum",
     "storage",
+]
+
+# Services OSISM deliberately does not deploy; the whole group family is absent
+# on purpose. Matched by name prefix so newly added sub-groups stay covered.
+IGNORE_NOT_DEPLOYED = [
+    "collectd",
+    "cyborg",
     "tacker",
     "telegraf",
-    "venus",
-    "vitrage",
 ]
 
 # kolla-ansible release tracked by this check. Pin to the stable branch OSISM
@@ -59,7 +59,8 @@ def missing_sections(local, upstream_config):
         section
         for section in upstream_config.sections()
         if section not in local
-        and not any(section.startswith(prefix) for prefix in IGNORE)
+        and section not in IGNORE_ROLE_GROUPS
+        and not any(section.startswith(p) for p in IGNORE_NOT_DEPLOYED)
     ]
 
 
@@ -99,8 +100,8 @@ def main():
         "    the same host group(s) kolla-ansible uses upstream (e.g. control,\n"
         "    compute, network, storage), keeping the section alphabetically\n"
         "    sorted.\n"
-        "  * OSISM intentionally does not deploy it -> add the group's name\n"
-        "    prefix to the IGNORE list in src/check-kolla-inventory.py.\n"
+        "  * OSISM intentionally does not deploy it -> add the service's name\n"
+        "    prefix to IGNORE_NOT_DEPLOYED in src/check-kolla-inventory.py.\n"
         "\n"
         "Leaving a required group undefined makes Ansible abort haproxy-config\n"
         "templating with \"'dict object' has no attribute '<group>'\".",

--- a/src/check-kolla-inventory.py
+++ b/src/check-kolla-inventory.py
@@ -64,6 +64,26 @@ def missing_sections(local, upstream_config):
     ]
 
 
+def stale_ignores(local, upstream_config):
+    """IGNORE entries that no longer suppress any unshipped upstream group.
+
+    An entry goes stale when the service is now shipped in the inventory, or
+    when kolla-ansible removed it from the tracked release. Besides being dead
+    weight, a stale prefix can silently hide a future upstream group that OSISM
+    actually needs -- exactly the drift this check exists to catch -- so it is
+    treated as an error.
+    """
+    sections = upstream_config.sections()
+    stale = []
+    for name in IGNORE_ROLE_GROUPS:
+        if name not in sections or name in local:
+            stale.append(name)
+    for prefix in IGNORE_NOT_DEPLOYED:
+        if not any(s.startswith(prefix) and s not in local for s in sections):
+            stale.append(prefix)
+    return stale
+
+
 def main():
     local = local_sections()
 
@@ -78,6 +98,24 @@ def main():
 
     upstream_config = ConfigParser(allow_no_value=True)
     upstream_config.read_file(io.StringIO(response.text))
+
+    stale = stale_ignores(local, upstream_config)
+    if stale:
+        print(
+            "ERROR: these IGNORE entries no longer suppress any upstream group "
+            "absent\nfrom "
+            + " and ".join(LOCAL_INVENTORY_FILES)
+            + ": "
+            + ", ".join(stale)
+            + "\n\n"
+            "They are stale -- the service is now shipped in the inventory, or "
+            "kolla-\nansible removed it from "
+            + KOLLA_BRANCH
+            + ". Remove them from IGNORE_ROLE_GROUPS\n"
+            "/ IGNORE_NOT_DEPLOYED in src/check-kolla-inventory.py.",
+            file=sys.stderr,
+        )
+        return 3
 
     missing = missing_sections(local, upstream_config)
     if not missing:

--- a/src/check-kolla-inventory.py
+++ b/src/check-kolla-inventory.py
@@ -2,9 +2,14 @@
 
 from configparser import ConfigParser
 import io
+import sys
 
 import requests
 
+# Group name prefixes that exist in the upstream kolla-ansible inventory but
+# that OSISM intentionally does not mirror. A group belongs here only if OSISM
+# deliberately never deploys the corresponding service; otherwise the group
+# must be defined in inventory/ instead (see the message printed on drift).
 IGNORE = [
     "baremetal",
     "blazar",
@@ -27,24 +32,82 @@ IGNORE = [
     "vitrage",
 ]
 
-config = ConfigParser(allow_no_value=True)
-config.read("inventory/50-kolla")
-sections = config.sections()
+# kolla-ansible release tracked by this check. Pin to the stable branch OSISM
+# currently deploys -- NOT master -- so the check flags groups that exist in
+# what OSISM ships rather than not-yet-released groups. Bump this whenever OSISM
+# moves to a new OpenStack release (see the OSISM developer guide, releases.md).
+KOLLA_BRANCH = "stable/2025.2"
+KOLLA_INVENTORY_URL = (
+    "https://raw.githubusercontent.com/openstack/kolla-ansible/"
+    f"{KOLLA_BRANCH}/ansible/inventory/multinode"
+)
 
-config = ConfigParser(allow_no_value=True)
-config.read("inventory/51-kolla")
-sections += config.sections()
+LOCAL_INVENTORY_FILES = ["inventory/50-kolla", "inventory/51-kolla"]
 
-url = "https://raw.githubusercontent.com/openstack/kolla-ansible/master/ansible/inventory/multinode"  # noqa
-response = requests.get(url, stream=True)
 
-config = ConfigParser(allow_no_value=True)
-config.read_file(io.StringIO(response.text))
-upstream_sections = config.sections()
+def local_sections():
+    sections = []
+    for path in LOCAL_INVENTORY_FILES:
+        config = ConfigParser(allow_no_value=True)
+        config.read(path)
+        sections += config.sections()
+    return sections
 
-for section in [x for x in upstream_sections if x not in sections]:
-    if not [x for x in IGNORE if section.startswith(x)]:
+
+def missing_sections(local, upstream_config):
+    return [
+        section
+        for section in upstream_config.sections()
+        if section not in local
+        and not any(section.startswith(prefix) for prefix in IGNORE)
+    ]
+
+
+def main():
+    local = local_sections()
+
+    response = requests.get(KOLLA_INVENTORY_URL)
+    if response.status_code != 200:
+        print(
+            "ERROR: failed to fetch upstream kolla-ansible inventory "
+            f"(HTTP {response.status_code}): {KOLLA_INVENTORY_URL}",
+            file=sys.stderr,
+        )
+        return 2
+
+    upstream_config = ConfigParser(allow_no_value=True)
+    upstream_config.read_file(io.StringIO(response.text))
+
+    missing = missing_sections(local, upstream_config)
+    if not missing:
+        return 0
+
+    for section in missing:
         print(f"[{section}]")
-        for x in config[section]:
-            print(x)
+        for member in upstream_config[section]:
+            print(member)
         print()
+    sys.stdout.flush()
+
+    print(
+        "The kolla-ansible inventory groups listed above exist upstream\n"
+        f"({KOLLA_INVENTORY_URL})\n"
+        "but are missing from " + " and ".join(LOCAL_INVENTORY_FILES) + ".\n"
+        "\n"
+        "Resolve each group, depending on whether OSISM deploys the service:\n"
+        "  * OSISM deploys it -> add the group to inventory/51-kolla, mapped to\n"
+        "    the same host group(s) kolla-ansible uses upstream (e.g. control,\n"
+        "    compute, network, storage), keeping the section alphabetically\n"
+        "    sorted.\n"
+        "  * OSISM intentionally does not deploy it -> add the group's name\n"
+        "    prefix to the IGNORE list in src/check-kolla-inventory.py.\n"
+        "\n"
+        "Leaving a required group undefined makes Ansible abort haproxy-config\n"
+        "templating with \"'dict object' has no attribute '<group>'\".",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,13 @@ deps = -r requirements.txt
 commands =
    python3 src/check-inventory-sorting.py
 
+[testenv:check-kolla]
+basepython = python3
+deps = -r requirements.txt
+
+commands =
+   python3 src/check-kolla-inventory.py
+
 [testenv:test]
 basepython = python3
 deps = -r requirements.txt


### PR DESCRIPTION
## What

Turn `src/check-kolla-inventory.py` into a **gating CI check** that fails when
this repo's Ansible inventory drifts from the kolla-ansible release OSISM
deploys. This is the class of bug behind the neutron 2025.2 groups and
`ironic-dnsmasq`: a group present upstream but absent here makes Ansible abort
with `'dict object' has no attribute '<group>'`.

## Commits

- `check-kolla-inventory: gate CI on missing groups` — exit non-zero on drift
  with remediation guidance; pin `KOLLA_BRANCH = stable/2025.2` (the deployed
  release) instead of `master`, so it flags real drift rather than
  not-yet-released groups.
- `check-kolla-inventory: clean up the IGNORE list` — split into
  `IGNORE_ROLE_GROUPS` (host-role groups, exact match) and
  `IGNORE_NOT_DEPLOYED` (services OSISM does not deploy, prefix match); drop 8
  stale entries.
- `check-kolla-inventory: guard against stale IGNORE` — fail when an IGNORE
  entry no longer suppresses any real upstream group (now shipped, or removed
  from the tracked release), so a stale prefix can't silently hide future
  drift.
- `zuul: run check-kolla-inventory as a gating job` — `check-kolla` tox env +
  voting `generics-tox-check-kolla` job in the `check` and `periodic-daily`
  pipelines.

## ⚠️ Depends on the ironic-dnsmasq fix

This branch is based on `main`, which does **not** yet contain the
`ironic-dnsmasq` inventory group. The new `generics-tox-check-kolla` job will
therefore fail on `ironic-dnsmasq` until that fix merges and this branch is
rebased. Merge order: the fix first, then this PR.

- osism/generics#601

## Maintenance

`KOLLA_BRANCH` must be bumped when OSISM moves to a new OpenStack series;
documented as a prerequisite in the developer-guide release checklist
(osism.github.io, `rewrite-releases-guide`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
