### PR TITLE
thanos_sidecar: remove the inventory group

### DIFF
--- a/inventory/50-monitoring
+++ b/inventory/50-monitoring
@@ -19,8 +19,5 @@ monitoring
 [scaphandre:children]
 generic
 
-[thanos_sidecar:children]
-prometheus
-
 [zabbix_agent:children]
 generic


### PR DESCRIPTION
## What

Removes the `[thanos_sidecar:children]` inventory group from `inventory/50-monitoring` — with the role and playbook gone it has no consumer.

## Why

Retire the thanos_sidecar role/service entirely (osism/issues#1402): its image
`quay.io/thanos/thanos` is frozen at `v0.32.5` (unchanged since 2023-12-18) and its
role-default `# renovate:` annotation is inert (the file is not in the collection's
`renovate.json` fileMatch), so it cannot be maintained — drop it rather than wire it
into release-managed pinning.

## Coordinated set — must land together

Four PRs for osism/issues#1402; deleting the role while its deploy playbook survives
would break the playbook, so they merge as a set:

- osism/ansible-collection-services#2136 — remove the role (+ molecule test + `.zuul.yaml` job)
- osism/ansible-playbooks#565 — remove the deploy playbook
- osism/generics#607 — remove the inventory group
- osism/osism.github.io#1025 — remove the network doc row

## ⚠️ Deploy-behaviour change

thanos_sidecar is **enabled by default** (`enable_thanos_sidecar | default('true')`) and
deploys to the `prometheus` group, so merging this set **stops deploying the Thanos
sidecar on the next run**. Please confirm this is acceptable for existing deployments.
