### PR TITLE
run.sh: fail fast when venv package install fails

### DIFF
--- a/environments/manager/run.sh
+++ b/environments/manager/run.sh
@@ -109,9 +109,9 @@ if [[ $INSTALL_ANSIBLE == "true" ]]; then
 
         # shellcheck source=/dev/null
         source "$VENV_PATH/bin/activate"
-        pip3 install uv
-        uv pip install -r requirements.txt
-        uv pip install "ansible==$ANSIBLE_VERSION"
+        pip3 install uv || exit $?
+        uv pip install -r requirements.txt || exit $?
+        uv pip install "ansible==$ANSIBLE_VERSION" || exit $?
 
     else
 


### PR DESCRIPTION
## Problem

The manager bootstrap `run.sh` venv seed path installed uv and the
Python/ansible environment without checking exit codes:

```sh
pip3 install uv
uv pip install -r requirements.txt
uv pip install "ansible==$ANSIBLE_VERSION"
```

Unlike the surrounding lines (`ansible-galaxy`, `osism.manager.*`), which use `|| exit $?`, these three swallowed any failure. When uv could not install — e.g. it failed to initialize its cache (`Failed to initialize cache at ~/.cache/uv: Permission denied`) — `run.sh` proceeded with a **half-built environment**: `requirements.txt` (which pulls in ansible plus collection dependencies such as `ansible.posix`) never installed, `ansible-galaxy` still installed the `osism.*` collections, and the `operator` playbook aborted much later with a misleading `couldn't resolve module/action 'ansible.posix.authorized_key' — No module named ansible_collections.ansible.posix`, tens of lines removed from the real cause.

Observed live in an autodrive/tbng deploy on regiocloud.

## Fix

Guard all three install lines with `|| exit $?` so a uv/pip failure aborts `run.sh` immediately with uv's own error message instead of producing a broken venv and a confusing downstream failure.

A targeted `|| exit $?` was chosen over `set -euo pipefail` deliberately: these exits occur *before* the `trap cleanup ERR EXIT` is registered (further down the script), so the fix cannot trigger `cleanup`'s `rm -rf "$VENV_PATH"` on the failure path.

## Impact on downstream copies

This file is also vendored by `cloud-in-a-box`, `metalbox`, the `generics-drift-*` repos, and tbng, which pick up the fix on their next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)