### PR TITLE
run.sh: accept environments/.vault_pass

### DIFF
--- a/environments/manager/run.sh
+++ b/environments/manager/run.sh
@@ -154,8 +154,14 @@ if [[ "$playbook" == "noop" ]]; then
     exit 0
 fi
 
+# Vault password file. environments/.vault_pass is the documented location and the
+# one the seed-container path above picks up; seen from this directory that file is
+# ../.vault_pass. The local .vault_pass stays the first candidate so configuration
+# repositories that keep it next to this script are unaffected.
 if [[ -e .vault_pass ]]; then
     VAULT=.vault_pass
+elif [[ -e ../.vault_pass ]]; then
+    VAULT=../.vault_pass
 elif [[ \
       $(head -1 secrets.yml | grep -v -q \$ANSIBLE_VAULT || echo 1) == 1 || \
       $(head -1 ../secrets.yml | grep -v -q \$ANSIBLE_VAULT || echo 1) == 1 || \


### PR DESCRIPTION
The two execution paths of `run.sh` look for the vault password file in different
places:

| | seed-container path | local venv path |
|---|---|---|
| `environments/.vault_pass` | picked up, forwarded as its in-container path | ignored |
| `environments/manager/.vault_pass` | ignored | picked up (`.vault_pass` next to the script) |

So there is no single location an operator can be told to use, and documentation that
names one has to add an exception for the other path — which is what the manager upgrade
guide has to do right now:

- osism/osism.github.io#1056

This looks for `../.vault_pass` as well, which is `environments/.vault_pass` seen from
`environments/manager`. The script changes into its own directory at the start, so the
relative path resolves like the other relative paths already used there. The existing
lookup stays the first candidate, so repositories that keep `.vault_pass` next to the
script are unaffected.

Deliberately one-directional: the container path is *not* taught to accept
`environments/manager/.vault_pass`. Making both locations work everywhere would leave
two valid answers to "where does the password go"; this way `environments/.vault_pass` is
the one location that works on every path, and the manager-level file remains only for
backwards compatibility where it already worked.

Checked by running the selection block against a scratch tree:

| files present | result |
|---|---|
| none, plaintext secrets | unset, as before |
| `environments/manager/.vault_pass` | `.vault_pass` — unchanged |
| `environments/.vault_pass` | `../.vault_pass` — new, previously unset |
| both | `.vault_pass` wins — unchanged |
| none, encrypted `secrets.yml` | `ANSIBLE_ASK_VAULT_PASS=true` — the fallthrough an added `elif` could have broken |

Draft: it pairs with the documentation change above, whose exception sentence can be
dropped once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)